### PR TITLE
Corrected ID for demand profile

### DIFF
--- a/influxdbreader.py
+++ b/influxdbreader.py
@@ -8,7 +8,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Returns an InfluxDB object of the typical demand profile from Energy Data Repository
 # The ID is passed to query the InfluxDB (see read_yearly_demand_profile_data(year) method)
 def get_influx_db_demand_profile():
-    return edrreader.get_item_from_EDR('5c10df35-2b34-444a-b501-b41cf95dd4d7')
+    return edrreader.get_item_from_EDR('a184cf10-6ffd-440c-b6a9-f15dd852eb15')
 
 
 # Queries the Energy Data Repository's https://edr.hesi.energy/api/ site to get an InfluxDB object of solar production  profiles


### PR DESCRIPTION
The previous demand profile EDR id is not valid anymore and returns an internal error 500 (which actually in my opinion must be a 404 if the resource is not found, but that's for later discussion!). The tutorial subsequently broke.